### PR TITLE
(#15) lexical binding: let

### DIFF
--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -90,6 +90,13 @@ eval env (List (Atom "lambda" : Pair params varargs : body)) =
   makeVarArgs varargs env params body
 eval env (List (Atom "lambda" : varargs@(Atom _) : body)) =
   makeVarArgs varargs env [] body
+eval env (List (Atom "let" : List bindings : body)) = do
+  -- make a lambda, because `(let ((x 1)) x)` is equal to `((lambda (x) (x)) 1)`
+  func <- makeNormalFunc env (map (\(List [var, _]) -> var) bindings) body
+  -- take inits as the argument of lambda
+  argVals <- mapM (eval env . (\(List [_, init]) -> init)) bindings
+  -- apply lambda
+  apply func argVals
 eval env (List [Atom "load", String filename]) =
   load filename >>= fmap last . mapM (eval env)
 -- `(+ 1 2 3)`


### PR DESCRIPTION
In this PR, we implement `let` lexical binding, for example:

```scm
(let ((x 2) (y 3))
  (* x y))                              ⇒  6

(let ((x 2) (y 3))
  (let ((foo (lambda (z) (+ x y z)))
        (x 7))
    (foo 4)))                           ⇒  9
```

Description(take from https://www.gnu.org/software/mit-scheme/documentation/mit-scheme-ref/Lexical-Binding.html):

> special form: let ((variable init) …) expression expression …
The inits are evaluated in the current environment (in some unspecified order), the variables are bound to fresh locations holding the results, the expressions are evaluated sequentially in the extended environment, and the value of the last expression is returned. Each binding of a variable has the expressions as its region.