### PR TITLE
(#21) conditionals: case

### DIFF
--- a/test/InterpreterSpec.hs
+++ b/test/InterpreterSpec.hs
@@ -1,12 +1,12 @@
 module InterpreterSpec where
 import SpecHelper
 
-import Core (ScmError, ScmValue(..), liftThrows, nullEnv)
+import Core (ScmError(..), ScmValue(..), liftThrows, nullEnv)
 import Interpreter (eval, primitiveBindings)
 import Parser (readExpr)
 
 import Control.Monad.Except (runExceptT)
-import Data.Either (isRight)
+import Data.Either (isLeft, isRight)
 
 spec :: Spec
 spec = describe "eval" $ do
@@ -16,12 +16,26 @@ spec = describe "eval" $ do
     it "Bool #t" $ runCode "#t" >>= (`shouldBe` Right (Bool True))
     it "Bool #f" $ runCode "#f" >>= (`shouldBe` Right (Bool False))
     it "cond should return the first successive clause expression" $
-      runCode "(cond ((> 3 2) 'greater) (#t 'less))" >>= (`shouldBe` Right (Atom "greater"))
+      runCode "(cond ((> 3 2) 'greater) (#t 'less))"
+      >>= (`shouldBe` Right (Atom "greater"))
+    it "cond would halt program when no clause success" $
+      runCode "(cond (#f 'succ))"
+      >>= (`shouldBe` Left (NonExhaustivePattern [List [Bool False, List [Atom "quote", Atom "succ"]]]))
+    it "case should return the first successive clause expression" $
+      runCode "(case (* 2 3) ((2 3 5 7) 'prime) ((1 4 6 8 9) 'composite))"
+      >>= (`shouldBe` Right (Atom "composite"))
+    it "case else clause should return expression anyway" $
+      runCode "(case (* 2 3) ((2 3 5 7) 'prime) (else 'composite))"
+      >>= (`shouldBe` Right (Atom "composite"))
+    it "case would halt program when no clause success" $
+      runCode "(case 6 ((1 2) 'succ))"
+      >>= (`shouldBe` Left (NonExhaustivePattern [List [List [Number 1, Number 2], List [Atom "quote", Atom "succ"]]]))
   context "Effect environment" $ do
     it "let* allow second binding is done in an env in which first binding is visible" $
       runCode "(let* ((x 1) (y x)) y)" >>= (`shouldBe` Right (Number 1))
     it "letrec allow binding use itself recursive" $
-      runCode "(letrec ((until (lambda (stop init) (if (> init stop) init (until stop (+ init 1)))))) (until 10 1))" >>= (`shouldBe` Right (Number 11))
+      runCode "(letrec ((until (lambda (stop init) (if (> init stop) init (until stop (+ init 1)))))) (until 10 1))"
+      >>= (`shouldBe` Right (Number 11))
   where
     runCode code = do
       let c = readExpr code


### PR DESCRIPTION
* case return first successive clause, which contains a object list and
result expression. If no object list matches key, return
NonExhaustivePattern error. else clause is special form in case form it
always return it's expression
* test case in matched and non-exhaustive condition
* add non-exhaustive test for cond

```scm
(case (* 2 3)
  ((2 3 5 7) 'prime)
  ((1 4 6 8 9) 'composite))
;;; composite
;;; it also can be
(case (* 2 3)
  ((2 3 5 7) 'prime)
  (else 'composite))
```

NOTE:
* in little scheme we do not return an unspecified value but an error